### PR TITLE
Updates to webform to prevent reloading the page when clicking submit.

### DIFF
--- a/maptivist/src/main/webapp/index.html
+++ b/maptivist/src/main/webapp/index.html
@@ -51,7 +51,7 @@
         <!--TODO: Connect this to the backend--> 
         <div class="form-popup-info" id="myForm">
             <span class="close" onclick="closeForm()">&times;</span>
-            <form onsubmit="createMarker()" action="/data" method = "GET" class="form-container">
+            <form class="form-container">
                 <h1>Fill in Marker</h1>
                 <label for="email"><b>Email</b></label>
                 <br>
@@ -89,8 +89,8 @@
                 <input type="text" placeholder="Enter link here" id="marker-link" name="marker-link">
                 <br>
 
-                <button type="submit" class="btn">Submit</button>
-                <button type="submit" class="btn cancel" onclick="closeForm()">Close</button>
+                <button type="button" class="btn" onclick="createMarker()">Submit</button>
+                <button type="button" class="btn cancel" onclick="closeForm()">Close</button>
             </form>
         </div>
     </div>


### PR DESCRIPTION
I think the tricky thing is that the "submit" button (when type="submit") on HTML forms does something special. It loads the "action" page and sends all of the form elements as url parameters. When "action" is empty, then it reloads the current page with the elements as url parameters. Reloading the page is what is causing initMap to be called.

There's more information here:
https://www.w3schools.com/html/html_forms.asp

So, one solution is just to use "type=button" buttons and NOT type="submit" buttons. That way we can trigger the javascript function without reloading the page.

The javascript will then have to also send a POST request to the "/markers" servlet to push the marker to the database, but I think that should be relatively straightforward.

This is an example of how to do that - I think it should get you unstuck